### PR TITLE
correct command to "list available versions"

### DIFF
--- a/resources/homepage.md
+++ b/resources/homepage.md
@@ -113,7 +113,7 @@ client to install (code(`App::Rakubrew`)code).
 ===)h1)
 
     (c(# list available versions)c)
-    rakubrew list
+    rakubrew available
     
     (c(# download and install the latest Rakudo on MoarVM version)c)
     rakubrew download


### PR DESCRIPTION
It seems that the command desired here to "list available versions" is `rakubrew available`, not `rakubrew list`, which lists *installed* versions.

Fixes #9 