### PR TITLE
added fish shell path instructions

### DIFF
--- a/resources/homepage.md.tmpl
+++ b/resources/homepage.md.tmpl
@@ -99,7 +99,11 @@ Put that file into a folder that's in your (code(`PATH`)code) and run
 
 Finally add the shim folder to your path:
 
+    (c(# Bash & ZSH)c)
     export PATH=$(rakubrew home)/shims:$PATH
+    
+    (c(# Fish)c)
+    fish_add_path -g -a (rakubrew home)/shims
 
 That's all!
 


### PR DESCRIPTION
adds instructions for adding the shims directory to your path in fish, and makes it explicit that the old instructions were for Bash & ZSH

I'd recommend the addition of similar instructions for Powershell & CMD since they are listed under "works about anywhere" but i don't know how those things work so I haven't included them. 

Note: I haven't tested this because of issues with cro & this repo (something on my end possibly)